### PR TITLE
Updated Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,21 +38,10 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.2)
-    capybara (2.18.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     erubi (1.7.1)
@@ -86,8 +75,6 @@ GEM
     passenger (5.2.3)
       rack
       rake (>= 0.8.1)
-    public_suffix (3.0.2)
-    puma (3.11.4)
     rack (2.0.4)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -120,7 +107,6 @@ GEM
       ffi (>= 0.5.0, < 2)
     ref (2.0.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -132,9 +118,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.11.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -160,25 +143,20 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.0.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
-  capybara (~> 2.13)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   passenger (>= 5.0.25)
-  puma (~> 3.7)
   rails (~> 5.1.5)
   sass-rails (~> 5.0)
-  selenium-webdriver
   therubyracer
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   2.0.1


### PR DESCRIPTION
Original Gemfile.lock was out of sync with the Gemfile, which
interfered with running bundle install in deployment mode.